### PR TITLE
require node 18 as tests have been limited to node 18 + 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/aruttkamp/ioBroker.rct"
   },
+  "engines": {
+    "node": ">= 18"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^2.6.6"
   },


### PR DESCRIPTION
As you have limited testing to node 18 and 20 and do no longer test the adapter at node 16 the adapter should require node 18 or newer at installation.