### PR TITLE
io-package.json Update

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -128,13 +128,18 @@
       "rct",
       "pv"
     ],
-    "licenseInformation": "MIT",
+     "license": "MIT",
+     "licenseInformation": {
+            "type": "free",
+            "license": "MIT"
+    },
     "platform": "Javascript/Node.js",
     "icon": "rct-logo.square.png",
     "enabled": true,
     "extIcon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
     "readme": "https://github.com/aruttkamp/ioBroker.rct/blob/main/README.md",
     "loglevel": "info",
+    "tier": 3,
     "mode": "daemon",
     "type": "energy",
     "compact": true,
@@ -143,7 +148,7 @@
     "materialize": true,
     "dependencies": [
       {
-        "js-controller": ">=2.0.0"
+        "js-controller": ">=3.3.22"
       }
     ]
   },

--- a/io-package.json
+++ b/io-package.json
@@ -128,7 +128,6 @@
       "rct",
       "pv"
     ],
-     "license": "MIT",
      "licenseInformation": {
             "type": "free",
             "license": "MIT"

--- a/io-package.json
+++ b/io-package.json
@@ -128,7 +128,7 @@
       "rct",
       "pv"
     ],
-    "license": "MIT",
+    "licenseInformation": "MIT",
     "platform": "Javascript/Node.js",
     "icon": "rct-logo.square.png",
     "enabled": true,


### PR DESCRIPTION
3 Punkte aktualisiert:

1: Lizenz aktualisiert:
[W114] "common.license" in io-package.json is deprecated. Please define object "common.licenseInformation"

2: Tier (Startpriorität für Adapter) eingefügt:
[W115] common.tier is required in io-package.json

3: Abhängigkeit für den js-controller aktualisiert
Gemäß: [ioBroker.example]/[JavaScript]/io-package.json