### PR TITLE
Resilience update for TCP connections to RCT inverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Other elements can be found in the code (file "rct/rc_core2.js"). Since this is 
 
 The object "battery.bat_status" indicates the status of a connected battery:
 * 0 -> charge/discharge (normal operation)
-*	3 -> Update? ( not sure ) 
-*	5 -> Start ? ( not sure )
+* 1 -> idle (no CAN-connection to inverter)
+* 3 -> connecting (inverter -> battery)
+* 5 -> synchronizing (inverter -> battery)
 * 8 -> calibrating - charging phase (0% --> 100%)
 * 1024 -> calibrating - discharge phase (xx% --> 0%)
 * 2048 -> balancing

--- a/main.js
+++ b/main.js
@@ -110,7 +110,7 @@ class Rct extends utils.Adapter {
 			// clearTimeout(timeout2);
 			// ...
 			// clearInterval(interval1);
-			rct.end(this.config.rct_ip, rctElements, this);
+			rct.end(this.config.rct_ip, this);
 			iobInstance.log.info('RCT: disconnected from server(main)');
 			this.setState('info.connection',false,true);
 			callback();

--- a/main.js
+++ b/main.js
@@ -96,7 +96,6 @@ class Rct extends utils.Adapter {
 		}
 
 		console.debug('onReady() rct.process(): start processing');
-		//this.setState('info.connection',true);
 		rct.process(this.config.rct_ip, rctElements, this);
 	}
 
@@ -104,15 +103,16 @@ class Rct extends utils.Adapter {
 	 * Is called when adapter shuts down - callback has to be called under any circumstances!
 	 * @param {() => void} callback
 	 */
-	onUnload(callback) {
+	async onUnload(callback) {
 		try {
 			// Here you must clear all timeouts or intervals that may still be active
 			// clearTimeout(timeout1);
 			// clearTimeout(timeout2);
 			// ...
 			// clearInterval(interval1);
-			this.setState('info.connection',false,true);
 			rct.end();
+			iobInstance.log.info('RCT: disconnected from server(main)');
+			this.setState('info.connection',false,true);
 			callback();
 		} catch (e) {
 			callback();

--- a/main.js
+++ b/main.js
@@ -110,7 +110,7 @@ class Rct extends utils.Adapter {
 			// clearTimeout(timeout2);
 			// ...
 			// clearInterval(interval1);
-			rct.end();
+			rct.end(this.config.rct_ip, rctElements, this);
 			iobInstance.log.info('RCT: disconnected from server(main)');
 			this.setState('info.connection',false,true);
 			callback();

--- a/main.js
+++ b/main.js
@@ -111,7 +111,6 @@ class Rct extends utils.Adapter {
 			// ...
 			// clearInterval(interval1);
 			rct.end(this.config.rct_ip, this);
-			iobInstance.log.info('RCT: disconnected from server(main)');
 			this.setState('info.connection',false,true);
 			callback();
 		} catch (e) {

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -58,6 +58,7 @@ rct.reconnect = function (host, iobInstance) {
 			iobInstance.log.error(`RCT: reconnection not working!`);
 			__client.destroy();
 			__client = null;
+			__connection = false;
 		}
 	}
 };
@@ -66,7 +67,7 @@ rct.end = function (host, iobInstance) {
 	clearTimeout(__reconnect);
 	clearInterval(__refreshTimeout);
 	__connection = false;
-	iobInstance.log.info('RCT: connection with server fully terminated');
+	iobInstance.log.info('RCT: connection with server terminated');
 	if (__client) {
 		try {
 			__client.end();
@@ -222,8 +223,7 @@ rct.process = function (host, rctElements, iobInstance) {
 	}
 
 	__client.on('end', () => {
-  		if (DEBUG_CONSOLE) console.debug('RCT: connection successfully closed.');
-		/*console.log('disconnected from server');
+		/*iobInstance.log.info('disconnected from server');
 		// clear refresh timeout and reconnect
 		if (__refreshTimeout) {
 			clearTimeout(__refreshTimeout);

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -54,13 +54,9 @@ rct.reconnect = function (host, iobInstance) {
 		try {
 			__client.end();
 			__client = null;
-			if (DEBUG_CONSOLE==true) {
-				console.log(`INFO RCT: disconnecting from server`);
-			}
+			iobInstance.log.info(`RCT: disconnecting from server`);
 		} catch (err) {
-			if (DEBUG_CONSOLE==true) {
-				console.log(`DEBUG RCT: reconnection not working!`);
-			}
+			iobInstance.log.error(`RCT: reconnection not working!`);
 			__client.destroy();
 			__client = null;
 		}
@@ -71,7 +67,7 @@ rct.end = function (host, iobInstance) {
 	clearTimeout(__reconnect);
 	clearInterval(__refreshTimeout);
 	__connection = false;
-	iobInstance.log.info('RCT: disconnected from server');
+	iobInstance.log.info('RCT: connection with server fully terminated');
 	if (__client) {
 		try {
 			__client.end();
@@ -95,7 +91,7 @@ rct.process = function (host, rctElements, iobInstance) {
 	}
 	
 	__client = net.createConnection({ host, port: 8899 }, () => {
-		__reconnect = setTimeout(rct.reconnect, 2000);
+		__reconnect = setTimeout(rct.reconnect(host, iobInstance), 2000);
 
 		if (!__connection) {
 			iobInstance.log.info(`RCT: connected to server at ${host}`);

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -127,7 +127,7 @@ rct.process = function (host, rctElements, iobInstance) {
 		}*/
 		__client = null;
 		__connection = false;
-		__refreshTimeout = setTimeout(() => rct.process(host, rctElements, iobInstance), (60000);
+		__refreshTimeout = setTimeout(() => rct.process(host, rctElements, iobInstance), 60000);
 	});
 
 	let dataBuffer = Buffer.alloc(0);

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -60,6 +60,8 @@ rct.reconnect = function (host, iobInstance) {
 			__client = null;
 			__connection = false;
 		}
+		clearTimeout(__reconnect);
+
 	}
 };
 
@@ -89,12 +91,14 @@ rct.process = function (host, rctElements, iobInstance) {
 		} catch (err) {
 			iobInstance.log.error('RCT: connection error! Previous stream not closed and closure failed!');
 		}
+		clearTimeout(__reconnect);
+		clearInterval(__refreshTimeout);
 		}
 	}
 	
 	__client = net.createConnection({ host, port: 8899 }, () => {
+		
 		__reconnect = setTimeout(() => rct.reconnect(host, iobInstance), 2000);
-
 		if (!__connection) {
 			iobInstance.log.info(`RCT: connected to server at ${host}`);
 			iobInstance.setState('info.connection',true,true);
@@ -128,6 +132,8 @@ rct.process = function (host, rctElements, iobInstance) {
 		__client.resetAndDestroy();
 		__client = null;
 		__connection = false;
+		clearTimeout(__reconnect);
+		clearInterval(__refreshTimeout);
 		__refreshTimeout = setTimeout(() => rct.process(host, rctElements, iobInstance), 60000);
 	});
 

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -69,7 +69,7 @@ rct.end = function (host, iobInstance) {
 	clearTimeout(__reconnect);
 	clearInterval(__refreshTimeout);
 	__connection = false;
-	iobInstance.log.info('RCT: connection with server terminated');
+	iobInstance.log.info(`RCT: terminated connection to server at ${host}`);
 	if (__client) {
 		try {
 			__client.end();

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -91,7 +91,7 @@ rct.process = function (host, rctElements, iobInstance) {
 	}
 	
 	__client = net.createConnection({ host, port: 8899 }, () => {
-		__reconnect = setTimeout(rct.reconnect(host, iobInstance), 2000);
+		__reconnect = setTimeout(() => rct.reconnect(host, iobInstance), 2000);
 
 		if (!__connection) {
 			iobInstance.log.info(`RCT: connected to server at ${host}`);

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -84,7 +84,9 @@ rct.process = function (host, rctElements, iobInstance) {
 	if (__client) {
 		if (__client.destroyed==false) {
 		try {
+			__client.end();
 			__client.destroy();
+			__client = null;
 			iobInstance.log.error('RCT: connection error! Previous stream not closed!');
 		} catch (err) {
 			iobInstance.log.error('RCT: connection error! Previous stream not closed and closure failed!');
@@ -127,6 +129,7 @@ rct.process = function (host, rctElements, iobInstance) {
 		iobInstance.log.error('RCT: connection error, please check ip address and network!');
 		__client = null;
 		__connection = false;
+		__client.destroy();
 		__refreshTimeout = setTimeout(() => rct.process(host, rctElements, iobInstance), 60000);
 	});
 

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -53,6 +53,8 @@ rct.reconnect = function () {
 	if (__client) {
 		try {
 			__client.end();
+			iobInstance.log.info('RCT: disconnecting from server');
+			
 		} catch (err) {
 			iobInstance.log.error('RCT: reconnection not working!');
 			__client.destroy();
@@ -128,6 +130,10 @@ rct.process = function (host, rctElements, iobInstance) {
 		__client = null;
 		__connection = false;
 		__refreshTimeout = setTimeout(() => rct.process(host, rctElements, iobInstance), 60000);
+	});
+
+	__client.on('close', () => {
+		iobInstance.log.info('RCT: disconnected from server');
 	});
 
 	let dataBuffer = Buffer.alloc(0);

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -84,9 +84,7 @@ rct.process = function (host, rctElements, iobInstance) {
 	if (__client) {
 		if (__client.destroyed==false) {
 		try {
-			__client.end();
-			__client.destroy();
-			__client = null;
+			__client.resetAndDestroy();
 			iobInstance.log.error('RCT: connection error! Previous stream not closed!');
 		} catch (err) {
 			iobInstance.log.error('RCT: connection error! Previous stream not closed and closure failed!');
@@ -127,9 +125,9 @@ rct.process = function (host, rctElements, iobInstance) {
 
 	__client.on('error', (err) => {
 		iobInstance.log.error('RCT: connection error, please check ip address and network!');
+		__client.resetAndDestroy();
 		__client = null;
 		__connection = false;
-		__client.destroy();
 		__refreshTimeout = setTimeout(() => rct.process(host, rctElements, iobInstance), 60000);
 	});
 

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -6,7 +6,7 @@ const rct = require('./rct_core2.js');
 module.exports = rct;
 
 // flag for local debugging
-const DEBUG_CONSOLE = false;
+const DEBUG_CONSOLE = true;
 let __refreshTimeout = null;
 let __reconnect = null;
 let __client = null;
@@ -53,10 +53,12 @@ rct.reconnect = function () {
 	if (__client) {
 		try {
 			__client.end();
-			console.log.info('RCT: disconnecting from server');
+			if (DEBUG_CONSOLE==true) {
+				console.log(`INFO RCT: disconnecting from server`);
 			
 		} catch (err) {
-			console.log.error('RCT: reconnection not working!');
+			if (DEBUG_CONSOLE==true) {
+				console.log(`DEBUG RCT: reconnection not working!`);
 			__client.destroy();
 		}
 	}

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -53,7 +53,6 @@ rct.reconnect = function (host, iobInstance) {
 	if (__client) {
 		try {
 			__client.end();
-			__client = null;
 			iobInstance.log.info(`RCT: disconnecting from server`);
 		} catch (err) {
 			iobInstance.log.error(`RCT: reconnection not working!`);
@@ -81,7 +80,7 @@ rct.end = function (host, iobInstance) {
 
 rct.process = function (host, rctElements, iobInstance) {
 
-	if (__client) {
+	if (__client.destroyed==false) {
 		try {
 			__client.destroy();
 			iobInstance.log.error('RCT: connection error! Previous stream not closed!');

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -53,10 +53,10 @@ rct.reconnect = function () {
 	if (__client) {
 		try {
 			__client.end();
-			iobInstance.log.info('RCT: disconnecting from server');
+			console.log.info('RCT: disconnecting from server');
 			
 		} catch (err) {
-			iobInstance.log.error('RCT: reconnection not working!');
+			console.log.error('RCT: reconnection not working!');
 			__client.destroy();
 		}
 	}

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -80,12 +80,14 @@ rct.end = function (host, iobInstance) {
 
 rct.process = function (host, rctElements, iobInstance) {
 
-	if (__client.destroyed==false) {
+	if (__client) {
+		if (__client.destroyed==false) {
 		try {
 			__client.destroy();
 			iobInstance.log.error('RCT: connection error! Previous stream not closed!');
 		} catch (err) {
 			iobInstance.log.error('RCT: connection error! Previous stream not closed and closure failed!');
+		}
 		}
 	}
 	

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -53,7 +53,7 @@ rct.reconnect = function (host, iobInstance) {
 	if (__client) {
 		try {
 			__client.end();
-			iobInstance.log.info(`RCT: disconnecting from server`);
+			//iobInstance.log.info(`RCT: disconnecting from server`);
 		} catch (err) {
 			iobInstance.log.error(`RCT: reconnection not working!`);
 			__client.destroy();
@@ -124,18 +124,14 @@ rct.process = function (host, rctElements, iobInstance) {
 
 	__client.on('error', (err) => {
 		iobInstance.log.error('RCT: connection error, please check ip address and network!');
-		/*try {
-			__client.end();
-		} catch (err) {
-			// ignore
-		}*/
 		__client = null;
 		__connection = false;
 		__refreshTimeout = setTimeout(() => rct.process(host, rctElements, iobInstance), 60000);
 	});
 
 	__client.on('close', () => {
-		iobInstance.log.info('RCT: disconnected from server');
+		//Test ob die Verbindung sauber abgebaut wurde.
+		//iobInstance.log.info('RCT: disconnected from server');
 	});
 
 	let dataBuffer = Buffer.alloc(0);

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -55,10 +55,11 @@ rct.reconnect = function () {
 			__client.end();
 			if (DEBUG_CONSOLE==true) {
 				console.log(`INFO RCT: disconnecting from server`);
-			
+			}
 		} catch (err) {
 			if (DEBUG_CONSOLE==true) {
 				console.log(`DEBUG RCT: reconnection not working!`);
+			}
 			__client.destroy();
 		}
 	}

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -49,10 +49,11 @@ rct.getStateInfo = function (rctName, iobInstance) {
 	return { channelName, stateName, stateFullName };
 };
 
-rct.reconnect = function () {
+rct.reconnect = function (host, iobInstance) {
 	if (__client) {
 		try {
 			__client.end();
+			__client = null;
 			if (DEBUG_CONSOLE==true) {
 				console.log(`INFO RCT: disconnecting from server`);
 			}
@@ -61,11 +62,12 @@ rct.reconnect = function () {
 				console.log(`DEBUG RCT: reconnection not working!`);
 			}
 			__client.destroy();
+			__client = null;
 		}
 	}
 };
 
-rct.end = function () {
+rct.end = function (host, iobInstance) {
 	clearTimeout(__reconnect);
 	clearInterval(__refreshTimeout);
 	__connection = false;

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -129,7 +129,6 @@ rct.process = function (host, rctElements, iobInstance) {
 
 	__client.on('error', (err) => {
 		iobInstance.log.error('RCT: connection error, please check ip address and network!');
-		__client.destroy();
 		__client = null;
 		__connection = false;
 		clearTimeout(__reconnect);

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -87,7 +87,7 @@ rct.process = function (host, rctElements, iobInstance) {
 		if (__client.destroyed===false) {
 		try {
 			__client.resetAndDestroy();
-			iobInstance.log.error('RCT: connection error! Previous stream not closed!');
+			iobInstance.log.error('RCT: connection error! Previous stream was not closed correctly!');
 		} catch (err) {
 			iobInstance.log.error('RCT: connection error! Previous stream not closed and closure failed!');
 		}

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -82,7 +82,7 @@ rct.end = function (host, iobInstance) {
 rct.process = function (host, rctElements, iobInstance) {
 
 	if (__client) {
-		if (__client.destroyed==false) {
+		if (__client.destroyed===false) {
 		try {
 			__client.resetAndDestroy();
 			iobInstance.log.error('RCT: connection error! Previous stream not closed!');

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -129,7 +129,7 @@ rct.process = function (host, rctElements, iobInstance) {
 
 	__client.on('error', (err) => {
 		iobInstance.log.error('RCT: connection error, please check ip address and network!');
-		__client.resetAndDestroy();
+		__client.destroy();
 		__client = null;
 		__connection = false;
 		clearTimeout(__reconnect);

--- a/rct/rct.js
+++ b/rct/rct.js
@@ -6,7 +6,7 @@ const rct = require('./rct_core2.js');
 module.exports = rct;
 
 // flag for local debugging
-const DEBUG_CONSOLE = true;
+const DEBUG_CONSOLE = false;
 let __refreshTimeout = null;
 let __reconnect = null;
 let __client = null;


### PR DESCRIPTION
Aufgrund der Meldung über erhöhten Speicherverbrauch bei Verbindungsproblemen (#124 ) habe ich versucht die Verbindung etwas "stabiler" zu gestalten, auch für die Fälle dass bei der Verbindung Probleme oder Abbrüche gibt.

1: Bei Verbindungsproblemen wird der Reconnect fest auf 60 Sekunden gestellt (da machen 10 Sekunden keinen Sinn)
2: "rct.end" und "rct.reconnect" wurden nicht korrekt aufgerufen, da fehlten wohl die Argumente
3: Tests eingebaut ob die Verbindung auch wirklich gekappt wurde und falls nicht -> "__client.destroy()" eingefügt

Bei mir laufen die Änderungen bisher gut, das sollte aber lange und gut getestet werden bevor das in ein Release einfließt.
Diesmal haben wir ja nicht so einen Zeitdruck (solange sich nicht noch andere an #124 dran hängen).