### PR TITLE
Update rct.js

### DIFF
--- a/rct/rct.js
+++ b/rct/rct.js
@@ -100,7 +100,7 @@ rct.process = function (host, rctElements, iobInstance) {
 		}
 	}
 
-	__client = net.createConnection({ host, port: 8899 }, () => {dev-server
+	__client = net.createConnection({ host, port: 8899 }, () => {
 
 		__reconnect = setTimeout(() => rct.reconnect(host, iobInstance), 2000);
 		if (!__connection) {


### PR DESCRIPTION
Gab es hier einen Tipp-Fehler? Oder war das gewollt?
Habe diesen einen Teil entfernt, dann lief der Adapter direkt wieder.

Beim Start deiner neuen Version hatte ich folgendes im Log:

host.iobroker | 2024-06-28 15:24:09.336 | warn | Do not restart adapter system.adapter.rct.0 because restart loop detected
-- | -- | -- | --
host.iobroker | 2024-06-28 15:24:09.334 | error | instance system.adapter.rct.0 terminated with code 6 (UNCAUGHT_EXCEPTION)
rct.0 | 2024-06-28 15:24:09.172 | info | terminating
rct.0 | 2024-06-28 15:24:08.670 | warn | Terminated (UNCAUGHT_EXCEPTION): Without reason
rct.0 | 2024-06-28 15:24:08.668 | info | terminating
rct.0 | 2024-06-28 15:24:08.666 | info | RCT: terminated connection to server at 192.168.178.70

**rct.0 | 2024-06-28 15:24:08.662 | error | dev is not defined
rct.0 | 2024-06-28 15:24:08.661 | error | ReferenceError: dev is not defined at Socket.<anonymous> (/opt/iobroker/node_modules/iobroker.rct/rct/rct.js:103:63) at Object.onceWrapper (node:events:631:28) at Socket.emit (node:events:529:35) at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1540:10)
rct.0 | 2024-06-28 15:24:08.659 | error | uncaught exception: dev is not defined**

rct.0 | 2024-06-28 15:24:08.564 | info | config rct_ip: 192.168.178.70
rct.0 | 2024-06-28 15:24:08.539 | info | starting. Version 1.2.10 in /opt/iobroker/node_modules/iobroker.rct, node: v18.20.2, js-controller: 5.0.19
