### PR TITLE
German translations missing

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -1,1 +1,10 @@
-{}
+{
+  "General settings": "Einstellungen",
+  "RCT ip-address": "RCT IP-Adresse",
+  "Local RCT inverter ip-address (i.e. 192.168.0.10)": "Lokale Adresse des RCT Wechselrichters (z.B. 192.168.0.10)",
+  "Refresh interval": "Aktualisierungsintervall",
+  "Desired refresh interval for elements in seconds (10 - 3600)": "Gewünschtes Intervall für die Aktualsierung von Elementen in Sekunden (10 - 3600)",
+  "Elements": "Elemente",
+  "Elements to be fetched from inverter (leave blank for standard)": "Elemente die vom Wechselrichter abgerufen werden sollen (Leer lassen für Standard)",
+  "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting": "Aktivieren der erweiterten Protokollierung der Kommunikation mit dem Wechselrichter (Achtung: Extrem Umfangreiche Protokollierung, nur für kurze Zeit aktivieren!!"
+}

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -1,10 +1,11 @@
 {
-  "General settings": "Einstellungen",
+  "General Settings": "Allgemeine Einstellungen",
   "RCT ip-address": "RCT IP-Adresse",
-  "Local RCT inverter ip-address (i.e. 192.168.0.10)": "Lokale Adresse des RCT Wechselrichters (z.B. 192.168.0.10)",
+  "Local RCT inverter ip-address (i.e. 192.168.0.10)": "Lokale IP-Adresse des RCT-Wechselrichters (z. B. 192.168.0.10)",
   "Refresh interval": "Aktualisierungsintervall",
-  "Desired refresh interval for elements in seconds (10 - 3600)": "Gewünschtes Intervall für die Aktualsierung von Elementen in Sekunden (10 - 3600)",
+  "Desired refresh interval for elements in seconds (10 - 3600)": "Gewünschtes Aktualisierungsintervall für Elemente in Sekunden (10 – 3600)",
   "Elements": "Elemente",
-  "Elements to be fetched from inverter (leave blank for standard)": "Elemente die vom Wechselrichter abgerufen werden sollen (Leer lassen für Standard)",
-  "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting": "Aktivieren der erweiterten Protokollierung der Kommunikation mit dem Wechselrichter (Achtung: Extrem Umfangreiche Protokollierung, nur für kurze Zeit aktivieren!!"
+  "Elements to be fetched from inverter (leave blank for standard)": "Vom Wechselrichter abzurufende Elemente (für Standard leer lassen)",
+  "Enable debugging": "Erweiterte Debug-Protokollierung aktivieren",
+  "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting!!)": "Aktivieren Sie die Debug-Protokollierung für die Wechselrichterkommunikation (Achtung: übermäßige Protokollierung, nur zur kurzfristigen Fehlerbehebung verwenden!!)"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -5,5 +5,6 @@
   "Refresh interval": "Refresh interval",
   "Desired refresh interval for elements in seconds (10 - 3600)": "Desired refresh interval for elements in seconds (10 - 3600)",
   "Elements": "Elements",
-  "Elements to be fetched from inverter (leave blank for standard)": "Elements to be fetched from inverter (leave blank for standard)"
+  "Elements to be fetched from inverter (leave blank for standard)": "Elements to be fetched from inverter (leave blank for standard)",
+  "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting": "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -1,10 +1,11 @@
 {
-  "General settings": "General settings",
+  "General Settings": "General Settings",
   "RCT ip-address": "RCT ip-address",
   "Local RCT inverter ip-address (i.e. 192.168.0.10)": "Local RCT inverter ip-address (i.e. 192.168.0.10)",
   "Refresh interval": "Refresh interval",
   "Desired refresh interval for elements in seconds (10 - 3600)": "Desired refresh interval for elements in seconds (10 - 3600)",
   "Elements": "Elements",
   "Elements to be fetched from inverter (leave blank for standard)": "Elements to be fetched from inverter (leave blank for standard)",
-  "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting": "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting"
+  "Enable debugging": "Enable debugging",
+  "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting!!)": "Enable debug logging for inverter communication (attention: excessive logging, use only for short term trouble-shooting!!)"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -4,7 +4,7 @@
     "items": {
         "General": {
             "type": "panel",
-            "label": "General settings",
+            "label": "General Settings",
             "items": {
                 "_Headline1": {
                     "newLine": true,


### PR DESCRIPTION
Wondering why no one mentioned that:

Seems that the auto-translation (in /lib/tools.js) does not work anymore and does not translate the entries in /admin/i18n/en to other languages anymore (if it ever correctly did).
I did at least do the translations to German manually, the translation via Yandex or Google still needs to be fixed.